### PR TITLE
消除按下按鈕後出現的outline

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -139,6 +139,11 @@
   vertical-align: middle;
 }
 
+button:focus {
+    outline: none;
+    outline: 0px auto -webkit-focus-ring-color;
+}
+
 /* 提醒訊息 */
 #wrapper {
   position: relative;


### PR DESCRIPTION
只加了兩行程式碼

現在按加入購物車、加入收藏按鈕之後，外圍不會再出現藍色框框